### PR TITLE
compatibility of "torch.linalg.svd"

### DIFF
--- a/pyiqa/archs/nrqm_arch.py
+++ b/pyiqa/archs/nrqm_arch.py
@@ -351,7 +351,7 @@ def nrqm(
     f3 = []
     for im in img_pyr:
         col = im2col(im, 5)
-        _, s, _ = torch.linalg.svd(col, compute_uv=False)
+        _, s, _ = torch.linalg.svd(col)
         f3.append(s)
     f3 = torch.cat(f3, dim=1)
 


### PR DESCRIPTION
```
TypeError: linalg_svd() got an unexpected keyword argument 'compute_uv'  
```

"compute_uv" in torch.linalg.svd is not further supported from PyTorch 1.90.

https://pytorch.org/docs/1.9.0/generated/torch.linalg.svd.html?highlight=svd#torch.linalg.svd