### PR TITLE
Add support for byte array and PIL.Image sources

### DIFF
--- a/pyiqa/utils/img_util.py
+++ b/pyiqa/utils/img_util.py
@@ -4,6 +4,7 @@ import numpy as np
 import os
 import torch
 from torchvision.utils import make_grid
+import io
 
 from PIL import Image
 import torchvision.transforms.functional as TF
@@ -20,15 +21,22 @@ def is_image_file(filename):
     return any(filename.endswith(extension) for extension in IMG_EXTENSIONS)
 
 
-def imread2tensor(img_path, rgb=False):
+def imread2tensor(img_source, rgb=False):
     """Read image to tensor.
 
     Args:
-        img_path (str): path of image
+        img_source (str, bytes, or PIL.Image): image filepath string, image contents as a bytearray or a PIL Image instance
         rgb: convert input to RGB if true
     """
-    assert is_image_file(img_path), f'{img_path} is not a valid image file.'
-    img = Image.open(img_path)
+    if type(img_source) == bytes:
+        img = Image.open(io.BytesIO(img_source))
+    elif type(img_source) == str:
+        assert is_image_file(img_source), f'{img_source} is not a valid image file.'
+        img = Image.open(img_source)
+    elif type(img_source) == Image.Image:
+        img = img_source
+    else:
+        raise Exception("Unsupported source type")
     if rgb:
         img = img.convert('RGB')
     img_tensor = TF.to_tensor(img)


### PR DESCRIPTION
This simple change allows to perform quality assessment for in-memory Image objects and image bytes contents.  This can be useful, for example, when you need to assess multiple frames extracted from a video stream. Usage is identical to the file-based interface. E.g.:

```
import pyiqa
brisque = pyiqa.create_metric('brisque')
...
res = brisque(frame_bytes)
```