### PR TITLE
Improve SSIM numerical stability by transforming operations into float64

### DIFF
--- a/pyiqa/archs/ssim_arch.py
+++ b/pyiqa/archs/ssim_arch.py
@@ -101,8 +101,8 @@ class SSIM(torch.nn.Module):
             X = X[..., crop_border:-crop_border, crop_border:-crop_border]
             Y = Y[..., crop_border:-crop_border, crop_border:-crop_border]
         
-        X = preprocess_rgb(X, self.test_y_channel, self.data_range, self.color_space)
-        Y = preprocess_rgb(Y, self.test_y_channel, self.data_range, self.color_space) 
+        X = preprocess_rgb(X, self.test_y_channel, self.data_range, self.color_space).to(torch.float64)
+        Y = preprocess_rgb(Y, self.test_y_channel, self.data_range, self.color_space).to(torch.float64)
 
         score = ssim(X, Y, data_range=self.data_range, downsample=self.downsample)
         return score
@@ -187,8 +187,8 @@ class MS_SSIM(torch.nn.Module):
         assert X.shape == Y.shape, 'Input and reference images should have the same shape, but got'
         f'{X.shape} and {Y.shape}'
 
-        X = preprocess_rgb(X, self.test_y_channel, self.data_range, self.color_space)
-        Y = preprocess_rgb(Y, self.test_y_channel, self.data_range, self.color_space) 
+        X = preprocess_rgb(X, self.test_y_channel, self.data_range, self.color_space).to(torch.float64)
+        Y = preprocess_rgb(Y, self.test_y_channel, self.data_range, self.color_space).to(torch.float64)
 
         score = ms_ssim(
             X, Y,
@@ -252,8 +252,8 @@ class CW_SSIM(torch.nn.Module):
         """
         # Whether calculate on y channel of ycbcr
         if test_y_channel and x.shape[1] == 3:
-            x = to_y_channel(x, 255, self.color_space)
-            y = to_y_channel(y, 255, self.color_space)
+            x = to_y_channel(x, 255, self.color_space).to(torch.float64)
+            y = to_y_channel(y, 255, self.color_space).to(torch.float64)
 
         pyr = SCFpyr_PyTorch(height=self.level, nbands=self.ori, scale_factor=2, device=x.device)
         cw_x = pyr.build(x)

--- a/pyiqa/archs/ssim_arch.py
+++ b/pyiqa/archs/ssim_arch.py
@@ -252,8 +252,8 @@ class CW_SSIM(torch.nn.Module):
         """
         # Whether calculate on y channel of ycbcr
         if test_y_channel and x.shape[1] == 3:
-            x = to_y_channel(x, 255, self.color_space).to(torch.float64)
-            y = to_y_channel(y, 255, self.color_space).to(torch.float64)
+            x = to_y_channel(x, 255, self.color_space)
+            y = to_y_channel(y, 255, self.color_space)
 
         pyr = SCFpyr_PyTorch(height=self.level, nbands=self.ori, scale_factor=2, device=x.device)
         cw_x = pyr.build(x)
@@ -292,5 +292,5 @@ class CW_SSIM(torch.nn.Module):
             Value of CW-SSIM metric in [0, 1] range.
         """
         assert X.shape == Y.shape, f'Input {X.shape} and reference images should have the same shape'
-        score = self.cw_ssim(X, Y, self.test_y_channel)
+        score = self.cw_ssim(X.to(torch.float64), Y.to(torch.float64), self.test_y_channel)
         return score


### PR DESCRIPTION
I encounter numerical issues when I calculate SSIM and MS-SSIM. Transform input tensor into float64 solved problem, I think pyiqa should do these data type transformation implicitly, since `float64` is necessary for numerical stability.