### PR TITLE
Update requirements.txt to depend on opencv-python-headless rather th…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ addict
 future
 lmdb
 numpy
-opencv-python
+opencv-python-headless
 pandas
 Pillow
 pyyaml


### PR DESCRIPTION
…an opencv-python

From opencv-python [documentation](https://pypi.org/project/opencv-python/) (referring to the headless package):
> You should always use these packages if you do not use cv2.imshow et al. 

Having the non-headless dependency is a real headache for server applications. If it can be avoided it would help a lot :)