### PR TITLE
Revise the Q-Align value range from [0,1] to [1,5]

### DIFF
--- a/pyiqa/default_model_configs.py
+++ b/pyiqa/default_model_configs.py
@@ -590,7 +590,7 @@ DEFAULT_CONFIGS = OrderedDict({
             'type': 'QAlign',
         },
         'metric_mode': 'NR',
-        'score_range': '0, 1',
+        'score_range': '1, 5',
     },
     'unique': {
         'metric_opts': {


### PR DESCRIPTION
Hello, I checked the range of metrics provided by the new version. The majority of the metrics are fine, but the range for Q-Align ("Q-ALIGN: Teaching LMMs for Visual Scoring via Discrete Text-Defined Levels.") appears inconsistent with the [1,5] given in the paper:
![image](https://github.com/user-attachments/assets/2b5f66c0-22cf-4935-9f9b-0f3a0a6c647e)

My experimental results also came out around 2, which is not within the [0,1] range stated in the document. This seems to be a typographical error. This PR corrects this issue~