### PR TITLE
Improve cache strategy

### DIFF
--- a/pyiqa/utils/download_util.py
+++ b/pyiqa/utils/download_util.py
@@ -66,13 +66,7 @@ def save_response_content(response, destination, file_size=None, chunk_size=3276
         if pbar is not None:
             pbar.close()
 
-ENV_PYIQA_HOME = 'PYIQA_HOME'
-DEFAULT_CACHE_DIR = os.path.join(get_dir(), 'checkpoints')
-
-def _get_pyiqa_home():
-    # use env PYIQA_HOME, if not set, use torch hub dir
-    pyiqa_home = os.path.expanduser(os.getenv(ENV_PYIQA_HOME, DEFAULT_CACHE_DIR))
-    return pyiqa_home
+DEFAULT_CACHE_DIR = os.path.join(get_dir(), 'pyiqa')
 
 
 def load_file_from_url(url, model_dir=None, progress=True, file_name=None):
@@ -90,7 +84,7 @@ def load_file_from_url(url, model_dir=None, progress=True, file_name=None):
     Returns:
         str: The path to the downloaded file.
     """
-    model_dir = model_dir or _get_pyiqa_home()
+    model_dir = model_dir or DEFAULT_CACHE_DIR
 
     os.makedirs(model_dir, exist_ok=True)
 

--- a/pyiqa/utils/download_util.py
+++ b/pyiqa/utils/download_util.py
@@ -66,6 +66,14 @@ def save_response_content(response, destination, file_size=None, chunk_size=3276
         if pbar is not None:
             pbar.close()
 
+ENV_PYIQA_HOME = 'PYIQA_HOME'
+DEFAULT_CACHE_DIR = os.path.join(get_dir(), 'checkpoints')
+
+def _get_pyiqa_home():
+    # use env PYIQA_HOME, if not set, use torch hub dir
+    pyiqa_home = os.path.expanduser(os.getenv(ENV_PYIQA_HOME, DEFAULT_CACHE_DIR))
+    return pyiqa_home
+
 
 def load_file_from_url(url, model_dir=None, progress=True, file_name=None):
     """Load file form http url, will download models if necessary.
@@ -82,11 +90,7 @@ def load_file_from_url(url, model_dir=None, progress=True, file_name=None):
     Returns:
         str: The path to the downloaded file.
     """
-    model_dir = model_dir or os.path.expanduser("~/.cache/pyiqa")
-
-    if model_dir is None:  # use the pytorch hub_dir
-        hub_dir = get_dir()
-        model_dir = os.path.join(hub_dir, 'checkpoints')
+    model_dir = model_dir or _get_pyiqa_home()
 
     os.makedirs(model_dir, exist_ok=True)
 


### PR DESCRIPTION
Previous implementation had a bug because `model_dir = model_dir or os.path.expanduser("~/.cache/pyiqa")`, so `model_dir` could never be None, therefore `model_dir` would not use the torch hub directory as the default value.

I propose adding a PyIQA environment variable `PYIQA_HOME`. If the user sets this environment variable, then the models will be saved in the corresponding directory. If not set, they will be saved in the default Pytorch Hub directory.

The reason for not using '~/.cache/pyiqa' as the default value is that users don't always have permission to access the user directory `~`, which is very common in cluster environments.