### PR TITLE
Make it possible to use pyiqa as a dependency on MacOS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 accelerate
 addict
-bitsandbytes
+bitsandbytes; sys_platform != 'darwin'
 einops
 facexlib
 future


### PR DESCRIPTION
The purpose of this change is to make it possible to use `pyiqa` as a dependency of another project, on MacOS machines.

Here's the error I got:

```
uv add pyiqa
Resolved 145 packages in 315ms
error: Distribution `bitsandbytes==0.45.3 @ registry+https://pypi.org/simple` can't be installed because it doesn't have a source distribution or wheel for the current platform
```

To work around this error, I changed `requirements.txt` such that it no longer attempts to install `bitsandbytes` on MacOS machine.  I think this should be fine because `bitsandbytes` is a wrapper around CUDA custom functions, which aren't relevant on MacOS.

After this change, I'm able to add `pyiqa` as a dependency:

```
uv sync
Resolved 145 packages in 305ms
   Built pyiqa @ file:///Users/ted/dev/IQA-PyTorch
Prepared 1 package in 376ms
Uninstalled 1 package in 6ms
Installed 1 package in 3ms
 ~ pyiqa==0.1.13 (from file:///Users/ted/dev/IQA-PyTorch)
```
