### PR TITLE
Fix order of distorted and reference images

### DIFF
--- a/pyiqa/data/general_fr_dataset.py
+++ b/pyiqa/data/general_fr_dataset.py
@@ -28,7 +28,7 @@ class GeneralFRDataset(BaseIQADataset):
             ref_path = osp.join(ref_img_folder, row[0])
             img_path = osp.join(target_img_folder, row[1])
             mos_label = float(row[2])
-            self.paths_mos.append([img_path, ref_path, mos_label])
+            self.paths_mos.append([ref_path, img_path, mos_label])
 
     def get_transforms(self, opt):
         # do paired transform first and then do common transform


### PR DESCRIPTION
This PR fixes a bug in `GeneralFRDataset`. On line 31, there is a [misplaced order](https://github.com/chaofengc/IQA-PyTorch/blob/main/pyiqa/data/general_fr_dataset.py#L31) of `ref_img` and `img`.

Across the whole code, the preserved order is `[reference_image, distorted_image]`: [here](https://github.com/chaofengc/IQA-PyTorch/blob/main/pyiqa/data/general_fr_dataset.py#L28) and [here](https://github.com/chaofengc/IQA-PyTorch/blob/main/pyiqa/data/general_fr_dataset.py#L73). The same order [is used](https://huggingface.co/datasets/chaofengc/IQA-PyTorch-Datasets-metainfo/blob/main/meta_info_CSIQDataset.csv#L1) in metadata, stored on HuggingFace. However, on line 31, their order is accidentally changed. This leads to a bug:
```python
%pip install git+https://github.com/chaofengc/IQA-PyTorch.git
from pyiqa import load_dataset


kadid10k = load_dataset('kadid10k')

assert torch.allclose(kadid10k[0]['img'], kadid10k[1]['img'])  # It should be False!
assert not torch.allclose(kadid10k[0]['ref_img'], kadid10k[1]['ref_img']) # It should be True!
```

Issue can be fixed after simply swapping values: 
`self.paths_mos.append([img_path, ref_path, mos_label])` 
→ `self.paths_mos.append([ref_path, img_path, mos_label])`