### PR TITLE
Remove inaccurate image validity check

### DIFF
--- a/pyiqa/utils/img_util.py
+++ b/pyiqa/utils/img_util.py
@@ -40,7 +40,6 @@ def imread2pil(img_source, rgb=False):
     if type(img_source) == bytes:
         img = Image.open(io.BytesIO(img_source))
     elif type(img_source) == str:
-        assert is_image_file(img_source), f'{img_source} is not a valid image file.'
         img = Image.open(img_source)
     elif isinstance(img_source, Image.Image):
         img = img_source
@@ -58,17 +57,7 @@ def imread2tensor(img_source, rgb=False):
         img_source (str, bytes, or PIL.Image): image filepath string, image contents as a bytearray or a PIL Image instance
         rgb: convert input to RGB if true
     """
-    if type(img_source) == bytes:
-        img = Image.open(io.BytesIO(img_source))
-    elif type(img_source) == str:
-        assert is_image_file(img_source), f'{img_source} is not a valid image file.'
-        img = Image.open(img_source)
-    elif isinstance(img_source, Image.Image):
-        img = img_source
-    else:
-        raise Exception('Unsupported source type')
-    if rgb:
-        img = img.convert('RGB')
+    img = imread2pil(img_source, rgb)
     img_tensor = TF.to_tensor(img)
     return img_tensor
 


### PR DESCRIPTION
Solves #260

Since we're opening the image with Pillow immediately after the check, we can simply skip it and let Pillow perform its own, more accurate image validity check. Note that the check function itself has been kept, as it’s used elsewhere in the code, apparently for dataset and directory filtering.

It might be worth considering the removal of this function in the remaining places as well, and handling any exceptions when the files are actually loaded. I’ll leave it to the maintainers to decide how this should be addressed.

I’ve also refactored `imread2tensor` to eliminate the code duplicated from `imread2pil`.