### PR TITLE
docs(model-cards): add score direction information

### DIFF
--- a/docs/ModelCard.md
+++ b/docs/ModelCard.md
@@ -8,50 +8,51 @@ import pyiqa
 print(pyiqa.list_models())
 ```
 
-| FR Method                | Model names                                                                                                                         | Description
-| ------------------------ |-------------------------------------------------------------------------------------------------------------------------------------| ------------ |
-| TOPIQ | `topiq_fr`, `topiq_fr-pipal`                                                                                                        | Proposed in [this paper](https://arxiv.org/abs/2308.03060) | 
-| AHIQ                     | `ahiq`                                                                                                                              |
-| PieAPP                   | `pieapp`                                                                                                                            |
-| LPIPS                    | `lpips`, `lpips-vgg`, `stlpips`, `stlpips-vgg`, `lpips+`, `lpips-vgg+`                                                                                      |
-| DISTS                    | `dists`                                                                                                                             |
-| WaDIQaM                  | `wadiqam_fr`                                                                                                                                     |  |
-| CKDN<sup>[1](#fn1)</sup> | `ckdn`                                                                                                                              |
-| FSIM                     | `fsim`                                                                                                                              |
-| SSIM                     | `ssim`, `ssimc`                                                                                                                     | Gray input (y channel), color input
-| MS-SSIM                  | `ms_ssim`                                                                                                                           |
-| CW-SSIM                  | `cw_ssim`                                                                                                                           |
-| PSNR                     | `psnr`, `psnry`                                                                                                                     | Color input, gray input (y channel)
-| VIF                      | `vif`                                                                                                                               |
-| GMSD                     | `gmsd`                                                                                                                              |
-| NLPD                     | `nlpd`                                                                                                                              |
-| VSI                      | `vsi`                                                                                                                               |
-| MAD                      | `mad`                                                                                                                               |
+| FR Method                | Model names                                                            | Description                                                | Score Direction  |
+| ------------------------ | ---------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------- |
+| TOPIQ                    | `topiq_fr`, `topiq_fr-pipal`                                           | Proposed in [this paper](https://arxiv.org/abs/2308.03060) | Higher is better |
+| AHIQ                     | `ahiq`                                                                 |                                                            | Higher is better |
+| PieAPP                   | `pieapp`                                                               |                                                            | Lower is better  |
+| LPIPS                    | `lpips`, `lpips-vgg`, `stlpips`, `stlpips-vgg`, `lpips+`, `lpips-vgg+` |                                                            | Lower is better  |
+| DISTS                    | `dists`                                                                |                                                            | Lower is better  |
+| WaDIQaM                  | `wadiqam_fr`                                                           |                                                            | Higher is better |
+| CKDN<sup>[1](#fn1)</sup> | `ckdn`                                                                 |                                                            | Higher is better |
+| FSIM                     | `fsim`                                                                 |                                                            | Higher is better |
+| SSIM                     | `ssim`, `ssimc`                                                        | Gray input (y channel), color input                        | Higher is better |
+| MS-SSIM                  | `ms_ssim`                                                              |                                                            | Higher is better |
+| CW-SSIM                  | `cw_ssim`                                                              |                                                            | Higher is better |
+| PSNR                     | `psnr`, `psnry`                                                        | Color input, gray input (y channel)                        | Higher is better |
+| VIF                      | `vif`                                                                  |                                                            | Higher is better |
+| GMSD                     | `gmsd`                                                                 |                                                            | Lower is better  |
+| NLPD                     | `nlpd`                                                                 |                                                            | Lower is better  |
+| VSI                      | `vsi`                                                                  |                                                            | Higher is better |
+| MAD                      | `mad`                                                                  |                                                            | Lower is better  |
 
-| NR Method                   | Model names                                                                                                         | Description                                                                                 |
-| --------------------------- |---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| Q-Align                 | `qalign` (with quality[default], aesthetic options)                                                                 | Large vision-language models                                                                |
- | QualiCLIP(+)            | `qualiclip`, `qualiclip+`, `qualiclip+-clive`, `qualiclip+-flive`, `qualiclip+-spaq`                                 | [QualiCLIP(+)](https://arxiv.org/abs/2403.11176) with different datasets, `koniq` by default |
-| LIQE | `liqe`, `liqe_mix`                                                                                                  | CLIP based method                                                                           |
-| ARNIQA                  | `arniqa`, `arniqa-live`, `arniqa-csiq`, `arniqa-tid`, `arniqa-kadid`, `arniqa-clive`, `arniqa-flive`, `arniqa-spaq` | [ARNIQA](https://arxiv.org/abs/2310.14918) with different datasets, `koniq` by default      |
-| TOPIQ | `topiq_nr`, `topiq_nr-flive`, `topiq_nr-spaq`                                                                       | [TOPIQ](https://arxiv.org/abs/2308.03060) with different datasets, `koniq` by default       |
-| TReS | `tres`, `tres-flive`                                                                                                | TReS with different datasets, `koniq` by default                                            |
-| FID                         | `fid`                                                                                                               | Statistic distance between two datasets                                                     |
-| CLIPIQA(+)                  | `clipiqa`, `clipiqa+`, `clipiqa+_vitL14_512`,`clipiqa+_rn50_512`                                                    | CLIPIQA(+) with different backbone, RN50 by default                                         |
-| MANIQA                      | `maniqa`, `maniqa-kadid`, `maniqa-pipal`                                                                            | MUSIQ with different datasets, `koniq` by default                                           |
-| MUSIQ                       | `musiq`, `musiq-spaq`, `musiq-paq2piq`, `musiq-ava`                                                                 | MUSIQ with different datasets, `koniq` by default                                           |
-| DBCNN                       | `dbcnn`                                                                                                             |
-| PaQ-2-PiQ                   | `paq2piq`                                                                                                           |
-| HyperIQA                    | `hyperiqa`                                                                                                          |
-| NIMA                        | `nima`, `nima-vgg16-ava`                                                                                            | Aesthetic metric trained with AVA dataset                                                   |
-| WaDIQaM                     | `wadiqam_nr`                                                                                                        |                                                                                             |                                                                
-| CNNIQA                      | `cnniqa`                                                                                                            |
-| NRQM(Ma)<sup>[2](#fn2)</sup> | `nrqm`                                                                                                              | No backward                                                                                 |
-| PI(Perceptual Index)        | `pi`                                                                                                                | No backward                                                                                 |
-| BRISQUE                     | `brisque`, `brisque_matlab`                                                                                         | No backward                                                                                 |
-| ILNIQE                      | `ilniqe`                                                                                                            | No backward                                                                                 |
-| NIQE                        | `niqe`, `niqe_matlab`                                                                                               | No backward                                                                                 |
-| PIQE                        | `piqe`                                                                                                              | No backward                                                                                 |
+
+| NR Method                    | Model names                                                                                                         | Description                                                                                  | Score Direction  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------- |--------------------------------------------------------------------------------------------- | ---------------- |
+| Q-Align                      | `qalign` (with quality[default], aesthetic options)                                                                 | Large vision-language models                                                                 | Higher is better |
+| QualiCLIP(+)                 | `qualiclip`, `qualiclip+`, `qualiclip+-clive`, `qualiclip+-flive`, `qualiclip+-spaq`                                | [QualiCLIP(+)](https://arxiv.org/abs/2403.11176) with different datasets, `koniq` by default | Higher is better |
+| LIQE                         | `liqe`, `liqe_mix`                                                                                                  | CLIP based method                                                                            | Higher is better |
+| ARNIQA                       | `arniqa`, `arniqa-live`, `arniqa-csiq`, `arniqa-tid`, `arniqa-kadid`, `arniqa-clive`, `arniqa-flive`, `arniqa-spaq` | [ARNIQA](https://arxiv.org/abs/2310.14918) with different datasets, `koniq` by default       | Higher is better |
+| TOPIQ                        | `topiq_nr`, `topiq_nr-flive`, `topiq_nr-spaq`                                                                       | [TOPIQ](https://arxiv.org/abs/2308.03060) with different datasets, `koniq` by default        | Higher is better |
+| TReS                         | `tres`, `tres-flive`                                                                                                | TReS with different datasets, `koniq` by default                                             | Higher is better |
+| FID                          | `fid`                                                                                                               | Statistic distance between two datasets                                                      | Lower is better  |
+| CLIPIQA(+)                   | `clipiqa`, `clipiqa+`, `clipiqa+_vitL14_512`,`clipiqa+_rn50_512`                                                    | CLIPIQA(+) with different backbone, RN50 by default                                          | Higher is better |
+| MANIQA                       | `maniqa`, `maniqa-kadid`, `maniqa-pipal`                                                                            | MUSIQ with different datasets, `koniq` by default                                            | Higher is better |
+| MUSIQ                        | `musiq`, `musiq-spaq`, `musiq-paq2piq`, `musiq-ava`                                                                 | MUSIQ with different datasets, `koniq` by default                                            | Higher is better |
+| DBCNN                        | `dbcnn`                                                                                                             |                                                                                              | Higher is better |
+| PaQ-2-PiQ                    | `paq2piq`                                                                                                           |                                                                                              | Higher is better |
+| HyperIQA                     | `hyperiqa`                                                                                                          |                                                                                              | Higher is better |
+| NIMA                         | `nima`, `nima-vgg16-ava`                                                                                            | Aesthetic metric trained with AVA dataset                                                    | Higher is better |
+| WaDIQaM                      | `wadiqam_nr`                                                                                                        |                                                                                              | Higher is better |
+| CNNIQA                       | `cnniqa`                                                                                                            |                                                                                              | Higher is better |
+| NRQM(Ma)<sup>[2](#fn2)</sup> | `nrqm`                                                                                                              | No backward                                                                                  | Higher is better |
+| PI(Perceptual Index)         | `pi`                                                                                                                | No backward                                                                                  | Lower is better  |
+| BRISQUE                      | `brisque`, `brisque_matlab`                                                                                         | No backward                                                                                  | Lower is better  |
+| ILNIQE                       | `ilniqe`                                                                                                            | No backward                                                                                  | Lower is better  |
+| NIQE                         | `niqe`, `niqe_matlab`                                                                                               | No backward                                                                                  | Lower is better  |
+| PIQE                         | `piqe`                                                                                                              | No backward                                                                                  | Lower is better  |
 <!-- </tr>
 </table> -->
 
@@ -60,11 +61,11 @@ print(pyiqa.list_models())
 
 ## IQA Methods for Specific Tasks
 
-| Task           | Method  | Description                                                                                                                                                                 |
-| -------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Color IQA | `msswd` | Perceptual color difference metric MS-SWD, ECCV2024, [Arxiv](http://arxiv.org/abs/2407.10181), [Github](https://github.com/real-hjq/MS-SWD)
-| Face IQA | `topiq_nr-face` | TOPIQ model trained with face IQA dataset (GFIQA) |
-| Underwater IQA | `uranker` | A ranking-based underwater image quality assessment (UIQA) method, AAAI2023, [Arxiv](https://arxiv.org/abs/2208.06857), [Github](https://github.com/RQ-Wu/UnderwaterRanker) |
+| Task           | Method          | Description                                                                                                                                                                 | Score Direction  |
+| -------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| Color IQA      | `msswd`         | Perceptual color difference metric MS-SWD, ECCV2024, [Arxiv](http://arxiv.org/abs/2407.10181), [Github](https://github.com/real-hjq/MS-SWD)                                 | Lower is better  |
+| Face IQA       | `topiq_nr-face` | TOPIQ model trained with face IQA dataset (GFIQA)                                                                                                                           | Higher is better |
+| Underwater IQA | `uranker`       | A ranking-based underwater image quality assessment (UIQA) method, AAAI2023, [Arxiv](https://arxiv.org/abs/2208.06857), [Github](https://github.com/RQ-Wu/UnderwaterRanker) | Higher is better |
 
 ## Metric Output Score Range
 **Note: `~` means that the corresponding numeric bound is typical value and not mathematically guaranteed**


### PR DESCRIPTION
## Description
This PR adds score direction information (Higher/Lower is better) to all model card tables, making it easier for users to interpret metric results without consulting individual paper references.

## Changes
- Added "Score Direction" column to FR Methods table
- Added "Score Direction" column to NR Methods table  
- Added "Score Direction" column to IQA Methods for Specific Tasks table
- Populated all columns with appropriate "Higher is better" or "Lower is better" values